### PR TITLE
Add Group Goals file

### DIFF
--- a/GROUP_GOALS_CHECKLIST.md
+++ b/GROUP_GOALS_CHECKLIST.md
@@ -1,0 +1,26 @@
+# Goals for PUG infrastructure
+#### Set up some Group infrastucture
+
+We want to set up some group infrastructure to further a few goals.
+- Increase the general level of professionalism in the way the group operates.
+- Make it easier for members of the community to interact with the group and for members to participate
+- Smooth any required transitions in group leadership in the future.
+
+#### Task List
+- [ ] Set up an online password manager account. LastPass comes to mind but others could be chosen.
+- [ ] Move presentation videos out of the repo and into youtube. Large files make the git clone take too long
+- [ ] Add a contributing md file to group repositories so users who want to add code can easily understand the standards we would like to enforce. The standard don't have to be as strict as other open source projects, but should be enough to maintain some level git ettiquette.
+- [ ] Create a github pages site for the group so that more flexible presenter bios and meeting announcements can be made
+- [ ] Create a group code of conduct that should be easily accessible from the pages site and should be included at the top level of all group repositories.
+- [ ] Create group PowerShell module for learning purposes
+   - The goal of the module that is simple enough that members can contribute cmdlets or refactor code as a way of learning how to contribute to PowerShell modules.
+   - The module should be hosted on github and use a deployment pipeline with a tbd server like AppVeyor to get it into the gallery for members to install.
+   - Advanced members can add issues to the repo for things like refactoring deliberately clunky code, or adding new cmdlets to do simple things.
+   - Less experienced members can then get used to not only writing code for others to review, but get some exposure to a collaberative, github workflow.
+- [ ] Create the necessary accounts for CI/CD tools, PowerShell gallery etc. 
+  - Add as bullets here things like the services chosen for each purpose and check those boxes once created and credentials added to the password manager.
+- [ ] Schedule a presentation for the group about participating a github workflow
+
+#### Guidelines
+- Services set up for the tasks above should not incur cost for group unless absolutely necessary.
+- Services should allow us to create an organizational account that contributing members can join using their own accounts and retain their own identities.


### PR DESCRIPTION
This change adds a file to track some future goals for the usergroup.
These goals are as much thinking out load about things to do and a
personal check list as anything. That said, anyone viewing the file is
welcome to take on any of the tasks and use github issues to discuss
how best those tasks might be accomplished. If you decide to complete a
task, please do a PR against the file with the checkbox checked so that
we can use, at least in part, to keep track of who has accomplished
which tasks.